### PR TITLE
Lower body animations fix

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -908,7 +908,10 @@ void C_NEO_Player::PostThink(void)
 	Vector eyeForward;
 	this->EyeVectors(&eyeForward, NULL, NULL);
 	Assert(eyeForward.IsValid());
-	m_pPlayerAnimState->Update(eyeForward[YAW], eyeForward[PITCH]);
+
+	float flPitch = asin(-eyeForward[2]);
+	float flYaw = atan2(eyeForward[1], eyeForward[0]);
+	m_pPlayerAnimState->Update(RAD2DEG(flYaw), RAD2DEG(flPitch));
 }
 
 bool C_NEO_Player::IsAllowedToSuperJump(void)

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1014,7 +1014,10 @@ void CNEO_Player::PostThink(void)
 	Vector eyeForward;
 	this->EyeVectors(&eyeForward, NULL, NULL);
 	Assert(eyeForward.IsValid());
-	m_pPlayerAnimState->Update(eyeForward[YAW], eyeForward[PITCH]);
+
+	float flPitch = asin(-eyeForward[2]);
+	float flYaw = atan2(eyeForward[1], eyeForward[0]);
+	m_pPlayerAnimState->Update(RAD2DEG(flYaw), RAD2DEG(flPitch));
 }
 
 void CNEO_Player::PlayerDeathThink()

--- a/mp/src/game/shared/hl2mp/hl2mp_player_shared.cpp
+++ b/mp/src/game/shared/hl2mp/hl2mp_player_shared.cpp
@@ -454,15 +454,31 @@ void CPlayerAnimState::ComputePoseParam_BodyXY(void)
 		sideSign = -1;
 	}
 
-	float speed_x = speedScale * forwardSign;
-	float speed_y = speedScale * sideSign;	
+
+	Vector eyeForward;
+	GetOuter()->EyeVectors(&eyeForward, NULL, NULL);
+	Assert(eyeForward.IsValid());
+	Vector velocity = GetOuter()->GetLocalVelocity();
+
+	Vector2D eyeForward2D = eyeForward.AsVector2D();
+	Vector2D velocity2D = velocity.AsVector2D();
+
+	eyeForward2D.NormalizeInPlace();
+	velocity2D.NormalizeInPlace();
+
+	float forwardDot = eyeForward2D[0] * velocity2D[0] + eyeForward2D[1] * velocity2D[1];
+	Vector2D eyeRight2D = Vector2D(eyeForward2D[1], eyeForward2D[0] * -1); // eyeForward2D rotated by 90 degrees
+	float sideDot = eyeRight2D[0] * velocity2D[0] + eyeRight2D[1] * velocity2D[1];
+
+	float speed_x = speedScale * forwardDot;
+	float speed_y = speedScale * sideDot;	
 
 	GetOuter()->SetPoseParameter(poseparam_move_x, speed_x);
 	GetOuter()->SetPoseParameter("move_y", speed_y);
 
 	bool bIsMoving;
 	const float flPlaybackRate = CalcMovementPlaybackRate(speed, GetOuter()->GetSequenceGroundSpeed(GetOuter()->GetSequence()), &bIsMoving) * sv_neo_animrate_scale.GetFloat();
-	
+
 	if (bIsMoving)
 	{
 		GetOuter()->SetPlaybackRate(flPlaybackRate);

--- a/mp/src/game/shared/hl2mp/hl2mp_player_shared.cpp
+++ b/mp/src/game/shared/hl2mp/hl2mp_player_shared.cpp
@@ -428,33 +428,6 @@ void CPlayerAnimState::ComputePoseParam_BodyXY(void)
 		((speed / ((GetOuter()->GetFlags() & FL_DUCKING) ? NEO_RECON_CROUCH_SPEED : NEO_RECON_NORM_SPEED))),
 		0, 1);
 
-	int forwardSign = 0;
-	if (GetOuter()->m_nButtons & IN_FORWARD)
-	{
-		if (!(GetOuter()->m_nButtons & IN_BACK))
-		{
-			forwardSign = 1;
-		}
-	}
-	else if (GetOuter()->m_nButtons & IN_BACK)
-	{
-		forwardSign = -1;
-	}
-
-	int sideSign = 0;
-	if (GetOuter()->m_nButtons & IN_MOVERIGHT)
-	{
-		if (!(GetOuter()->m_nButtons & IN_MOVELEFT))
-		{
-			sideSign = 1;
-		}
-	}
-	else if (GetOuter()->m_nButtons & IN_MOVELEFT)
-	{
-		sideSign = -1;
-	}
-
-
 	Vector eyeForward;
 	GetOuter()->EyeVectors(&eyeForward, NULL, NULL);
 	Assert(eyeForward.IsValid());


### PR DESCRIPTION
m_pPlayerAnimState->Update() expects two angles (pitch and yaw) in degrees, not two parts of a vector. Now its fixed

ComputePoseParam_BodyXY used m_nButtons to work out in which direction the legs should move. Since m_nButtons is not a networked variable, it wasn't possible to play leg animations for any other players except the local player. Now ComputePoseParam_BodyXY instead computes the player direction of travel in relation to the players camera (dot product between camera angle and velocity for whether player is going forwards or backwards and dot product between camera angle rotated by 90 degrees and velocity for whether the player is going left or right)

Retaining the speedscale and normalising the two vectors results in the smoothest animation. 
NOTE Since division is a computationally expensive operation, can discuss whether normalising the two vectors for every player object every update is worth it