### PR TITLE
Changing the "default_clip" values in the weapon files for the grenades to match the amount you get of them in current NT

### DIFF
--- a/mp/game/neo/scripts/weapon_grenade.txt
+++ b/mp/game/neo/scripts/weapon_grenade.txt
@@ -12,7 +12,7 @@ WeaponData
 
 	"clip_size"			"-1"
 	"clip2_size"			"-1"
-	"default_clip"			"3"
+	"default_clip"			"1"
 	"default_clip2"			"-1"
 
 	"primary_ammo"			"AMMO_GRENADE"

--- a/mp/game/neo/scripts/weapon_smokegrenade.txt
+++ b/mp/game/neo/scripts/weapon_smokegrenade.txt
@@ -11,7 +11,7 @@ WeaponData
 
 	"clip_size"			"-1"
 	"clip2_size"			"-1"
-	"default_clip"			"3"
+	"default_clip"			"2"
 	"default_clip2"			"-1"
 
 	"primary_ammo"			"AMMO_SMOKEGRENADE"

--- a/mp/game/neo/scripts/weapon_srm.txt
+++ b/mp/game/neo/scripts/weapon_srm.txt
@@ -9,7 +9,7 @@ WeaponData
 	"anim_prefix"		"srm"
 	"bucket"		"0"
 	"bucket_position"	"0"
-	"Damage"		"16"
+	"Damage"		"12"
 	"Penetration"		"20.0"
 	"CycleTime"		"0.06"		// time between shots
 	

--- a/mp/src/game/shared/neo/weapons/weapon_srm.h
+++ b/mp/src/game/shared/neo/weapons/weapon_srm.h
@@ -53,7 +53,7 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.08f; }
+	virtual float GetFireRate(void) OVERRIDE { return 0.06f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }


### PR DESCRIPTION
Fixes one of the issues mentioned in https://github.com/NeotokyoRevamp/neo/issues/84

Not sure if this is a bandaid fix, but it seems to work