### PR TITLE
Picking up weapons gives correct amount of ammo

### DIFF
--- a/mp/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/mp/src/game/server/hl2mp/hl2mp_player.cpp
@@ -610,6 +610,11 @@ void CHL2MP_Player::FireBullets ( const FireBulletsInfo_t &info )
 	lagcompensation->FinishLagCompensation( this );
 }
 
+void CHL2MP_Player::Weapon_Equip(CBaseCombatWeapon* pWeapon)
+{
+	CHL2_Player::Weapon_Equip(pWeapon);
+}
+
 void CHL2MP_Player::NoteWeaponFired( void )
 {
 	Assert( m_pCurrentCommand );

--- a/mp/src/game/server/hl2mp/hl2mp_player.h
+++ b/mp/src/game/server/hl2mp/hl2mp_player.h
@@ -71,6 +71,7 @@ public:
 	virtual int OnTakeDamage( const CTakeDamageInfo &inputInfo );
 	virtual bool WantsLagCompensationOnEntity( const CBasePlayer *pPlayer, const CUserCmd *pCmd, const CBitVec<MAX_EDICTS> *pEntityTransmitBits ) const;
 	virtual void FireBullets ( const FireBulletsInfo_t &info );
+	virtual void Weapon_Equip(CBaseCombatWeapon* pWeapon) override;
 	virtual bool Weapon_Switch( CBaseCombatWeapon *pWeapon, int viewmodelindex = 0);
 	virtual bool BumpWeapon( CBaseCombatWeapon *pWeapon );
 	virtual void ChangeTeam( int iTeam );

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1446,8 +1446,47 @@ void CNEO_Player::FireBullets ( const FireBulletsInfo_t &info )
 	BaseClass::FireBullets(info);
 }
 
+void CNEO_Player::Weapon_Equip(CBaseCombatWeapon* pWeapon)
+{
+	for (int i=0;i<MAX_WEAPONS;i++) 
+	{
+		if (!m_hMyWeapons[i]) 
+		{
+			m_hMyWeapons.Set( i, pWeapon );
+			break;
+		}
+	}
+	
+	pWeapon->ChangeTeam( GetTeamNumber() );
+	
+	if (pWeapon->GetMaxClip1() == -1)
+	{
+			GiveAmmo(pWeapon->GetDefaultClip1(), pWeapon->m_iPrimaryAmmoType, false); 
+	}
+	else if(pWeapon->m_iClip1 > pWeapon->GetMaxClip1())
+	{
+		pWeapon->m_iClip1 = pWeapon->GetMaxClip1();
+		GiveAmmo( pWeapon->GetDefaultClip1() - pWeapon->GetMaxClip1(), pWeapon->m_iPrimaryAmmoType, false); 
+	}
+
+	if (pWeapon->GetMaxClip2() == -1)
+	{
+		GiveAmmo(pWeapon->GetDefaultClip2(), pWeapon->m_iSecondaryAmmoType, false); 
+	}
+	else if(pWeapon->m_iClip2 > pWeapon->GetMaxClip2())
+	{
+		pWeapon->m_iClip2 = pWeapon->GetMaxClip2();
+		GiveAmmo( pWeapon->GetDefaultClip2() - pWeapon->GetMaxClip2(), pWeapon->m_iSecondaryAmmoType, false); 
+	}
+	
+	pWeapon->Equip( this );
+
+	// Pass the lighting origin over to the weapon if we have one
+	pWeapon->SetLightingOriginRelative( GetLightingOriginRelative() );
+}	
+
 bool CNEO_Player::Weapon_Switch( CBaseCombatWeapon *pWeapon,
-	int viewmodelindex )
+                                 int viewmodelindex )
 {
 	ShowCrosshair(false);
 

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -50,6 +50,7 @@ public:
 	virtual float GetReceivedDamageScale(CBaseEntity* pAttacker) OVERRIDE;
 	virtual bool WantsLagCompensationOnEntity(const CBasePlayer *pPlayer, const CUserCmd *pCmd, const CBitVec<MAX_EDICTS> *pEntityTransmitBits) const OVERRIDE;
 	virtual void FireBullets(const FireBulletsInfo_t &info) OVERRIDE;
+	virtual void Weapon_Equip(CBaseCombatWeapon* pWeapon) OVERRIDE;
 	virtual bool Weapon_Switch(CBaseCombatWeapon *pWeapon, int viewmodelindex = 0) OVERRIDE;
 	virtual bool Weapon_CanSwitchTo(CBaseCombatWeapon *pWeapon) OVERRIDE;
 	virtual bool BumpWeapon(CBaseCombatWeapon *pWeapon) OVERRIDE;


### PR DESCRIPTION
Override default functionality of giving weapons to a player
Picking up a new weapon does not give player default amount of ammo as well