### PR TITLE
Fix holstering a nade after pin was pulled forcing user to throw it straight away when switching back to it

### DIFF
--- a/mp/src/game/shared/neo/weapons/weapon_grenade.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_grenade.cpp
@@ -90,6 +90,7 @@ bool CWeaponGrenade::Holster(CBaseCombatWeapon *pSwitchingTo)
 {
 	m_bRedraw = false;
 	m_fDrawbackFinished = false;
+	m_AttackPaused = GRENADE_PAUSED_NO;
 
 	return BaseClass::Holster(pSwitchingTo);
 }

--- a/mp/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
@@ -68,6 +68,7 @@ bool CWeaponSmokeGrenade::Holster(CBaseCombatWeapon* pSwitchingTo)
 {
 	m_bRedraw = false;
 	m_fDrawbackFinished = false;
+	m_AttackPaused = GRENADE_PAUSED_NO;
 
 	return BaseClass::Holster(pSwitchingTo);
 }


### PR DESCRIPTION
Holstering a nade puts the pin back