### PR TITLE
Hold to aim - cvar: neo_aim_hold

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -888,9 +888,13 @@ void C_NEO_Player::PostThink(void)
 		{
 			Weapon_SetZoom(false);
 		}
+		else if (cl_aimhold.GetBool() && m_afButtonPressed & IN_AIM)
+		{
+			Weapon_AimToggle(pWep, NEO_TOGGLE_FORCE_AIM);
+		}
 		else if ((m_afButtonReleased & IN_AIM) && (!(m_nButtons & IN_SPEED)))
 		{
-			Weapon_AimToggle(pWep);
+			Weapon_AimToggle(pWep, cl_aimhold.GetBool() ? NEO_TOGGLE_FORCE_UN_AIM : NEO_TOGGLE_DEFAULT);
 		}
 
 #if !defined( NO_ENTITY_PREDICTION )
@@ -1204,7 +1208,7 @@ float C_NEO_Player::GetActiveWeaponSpeedScale() const
 	return (pWep ? pWep->GetSpeedScale() : 1.0f);
 }
 
-void C_NEO_Player::Weapon_AimToggle(C_BaseCombatWeapon *pWep)
+void C_NEO_Player::Weapon_AimToggle(C_BaseCombatWeapon *pWep, const NeoWeponAimToggleE toggleType)
 {
 	// NEO TODO/HACK: Not all neo weapons currently inherit
 	// through a base neo class, so we can't static_cast!!
@@ -1217,12 +1221,12 @@ void C_NEO_Player::Weapon_AimToggle(C_BaseCombatWeapon *pWep)
 	// This implies the wep ptr is valid, so we don't bother checking
 	if (IsAllowedToZoom(neoCombatWep))
 	{
-		if (neoCombatWep->IsReadyToAimIn())
+		if (toggleType != NEO_TOGGLE_FORCE_UN_AIM && neoCombatWep->IsReadyToAimIn())
 		{
 			const bool showCrosshair = (m_Local.m_iHideHUD & HIDEHUD_CROSSHAIR) == HIDEHUD_CROSSHAIR;
 			Weapon_SetZoom(showCrosshair);
 		}
-		else
+		else if (toggleType != NEO_TOGGLE_FORCE_AIM)
 		{
 			Weapon_SetZoom(false);
 		}

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -888,13 +888,13 @@ void C_NEO_Player::PostThink(void)
 		{
 			Weapon_SetZoom(false);
 		}
-		else if (cl_aimhold.GetBool() && m_afButtonPressed & IN_AIM)
+		else if (neo_aim_hold.GetBool() && m_afButtonPressed & IN_AIM)
 		{
 			Weapon_AimToggle(pWep, NEO_TOGGLE_FORCE_AIM);
 		}
 		else if ((m_afButtonReleased & IN_AIM) && (!(m_nButtons & IN_SPEED)))
 		{
-			Weapon_AimToggle(pWep, cl_aimhold.GetBool() ? NEO_TOGGLE_FORCE_UN_AIM : NEO_TOGGLE_DEFAULT);
+			Weapon_AimToggle(pWep, neo_aim_hold.GetBool() ? NEO_TOGGLE_FORCE_UN_AIM : NEO_TOGGLE_DEFAULT);
 		}
 
 #if !defined( NO_ENTITY_PREDICTION )

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -888,13 +888,13 @@ void C_NEO_Player::PostThink(void)
 		{
 			Weapon_SetZoom(false);
 		}
-		else if (neo_aim_hold.GetBool() && m_afButtonPressed & IN_AIM)
+		else if (ClientWantsAimHold(this) && m_afButtonPressed & IN_AIM)
 		{
 			Weapon_AimToggle(pWep, NEO_TOGGLE_FORCE_AIM);
 		}
 		else if ((m_afButtonReleased & IN_AIM) && (!(m_nButtons & IN_SPEED)))
 		{
-			Weapon_AimToggle(pWep, neo_aim_hold.GetBool() ? NEO_TOGGLE_FORCE_UN_AIM : NEO_TOGGLE_DEFAULT);
+			Weapon_AimToggle(pWep, ClientWantsAimHold(this) ? NEO_TOGGLE_FORCE_UN_AIM : NEO_TOGGLE_DEFAULT);
 		}
 
 #if !defined( NO_ENTITY_PREDICTION )

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -144,7 +144,7 @@ public:
 
 	void DrawCompass(void);
 
-	void Weapon_AimToggle(C_BaseCombatWeapon *pWep);
+	void Weapon_AimToggle(C_BaseCombatWeapon *pWep, const NeoWeponAimToggleE toggleType);
 	void Weapon_SetZoom(const bool bZoomIn);
 
 	void Weapon_Drop(C_NEOBaseCombatWeapon *pWeapon);

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -973,14 +973,14 @@ void CNEO_Player::PostThink(void)
 			{
 				static_cast<CWeaponGrenade*>(pNeoWep)->SecondaryAttack();
 			}
-			else if (neo_aim_hold.GetBool())
+			else if (ClientWantsAimHold(this))
 			{
 				Weapon_AimToggle(pWep, NEO_TOGGLE_FORCE_AIM);
 			}
 		}
 		else if (m_afButtonReleased & IN_AIM)
 		{
-			Weapon_AimToggle(pWep, neo_aim_hold.GetBool() ? NEO_TOGGLE_FORCE_UN_AIM : NEO_TOGGLE_DEFAULT);
+			Weapon_AimToggle(pWep, ClientWantsAimHold(this) ? NEO_TOGGLE_FORCE_UN_AIM : NEO_TOGGLE_DEFAULT);
 		}
 		m_bPreviouslyReloading = pWep->m_bInReload;
 

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -973,15 +973,14 @@ void CNEO_Player::PostThink(void)
 			{
 				static_cast<CWeaponGrenade*>(pNeoWep)->SecondaryAttack();
 			}
-			else
+			else if (cl_aimhold.GetBool())
 			{
-				// NEO TODO (Rain): customizations for aim pressed/released/held behavior
-				//if (pNeoWep != NULL) { Weapon_AimToggle(pWep); }
+				Weapon_AimToggle(pWep, NEO_TOGGLE_FORCE_AIM);
 			}
 		}
 		else if (m_afButtonReleased & IN_AIM)
 		{
-			Weapon_AimToggle(pWep);
+			Weapon_AimToggle(pWep, cl_aimhold.GetBool() ? NEO_TOGGLE_FORCE_UN_AIM : NEO_TOGGLE_DEFAULT);
 		}
 		m_bPreviouslyReloading = pWep->m_bInReload;
 
@@ -1022,7 +1021,7 @@ void CNEO_Player::PlayerDeathThink()
 	BaseClass::PlayerDeathThink();
 }
 
-void CNEO_Player::Weapon_AimToggle(CNEOBaseCombatWeapon* pNeoWep)
+void CNEO_Player::Weapon_AimToggle(CNEOBaseCombatWeapon* pNeoWep, const NeoWeponAimToggleE toggleType)
 {
 	if (!pNeoWep)
 	{
@@ -1031,23 +1030,23 @@ void CNEO_Player::Weapon_AimToggle(CNEOBaseCombatWeapon* pNeoWep)
 
 	if (IsAllowedToZoom(pNeoWep))
 	{
-		if (pNeoWep->IsReadyToAimIn())
+		if (toggleType != NEO_TOGGLE_FORCE_UN_AIM && pNeoWep->IsReadyToAimIn())
 		{
 			const bool showCrosshair = (m_Local.m_iHideHUD & HIDEHUD_CROSSHAIR) == HIDEHUD_CROSSHAIR;
 			Weapon_SetZoom(showCrosshair);
 		}
-		else
+		else if (toggleType != NEO_TOGGLE_FORCE_AIM)
 		{
 			Weapon_SetZoom(false);
 		}
 	}
 }
 
-void CNEO_Player::Weapon_AimToggle(CBaseCombatWeapon *pWep)
+void CNEO_Player::Weapon_AimToggle(CBaseCombatWeapon *pWep, const NeoWeponAimToggleE toggleType)
 {
 	// NEO TODO/HACK: Not all neo weapons currently inherit
 	// through a base neo class, so we can't static_cast!!
-	Weapon_AimToggle(dynamic_cast<CNEOBaseCombatWeapon*>(pWep));
+	Weapon_AimToggle(dynamic_cast<CNEOBaseCombatWeapon*>(pWep), toggleType);
 }
 
 void CNEO_Player::Weapon_SetZoom(const bool bZoomIn)

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -973,14 +973,14 @@ void CNEO_Player::PostThink(void)
 			{
 				static_cast<CWeaponGrenade*>(pNeoWep)->SecondaryAttack();
 			}
-			else if (cl_aimhold.GetBool())
+			else if (neo_aim_hold.GetBool())
 			{
 				Weapon_AimToggle(pWep, NEO_TOGGLE_FORCE_AIM);
 			}
 		}
 		else if (m_afButtonReleased & IN_AIM)
 		{
-			Weapon_AimToggle(pWep, cl_aimhold.GetBool() ? NEO_TOGGLE_FORCE_UN_AIM : NEO_TOGGLE_DEFAULT);
+			Weapon_AimToggle(pWep, neo_aim_hold.GetBool() ? NEO_TOGGLE_FORCE_UN_AIM : NEO_TOGGLE_DEFAULT);
 		}
 		m_bPreviouslyReloading = pWep->m_bInReload;
 

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -114,8 +114,8 @@ public:
 
 	void UpdateNetworkedFriendlyLocations(void);
 
-	void Weapon_AimToggle(CBaseCombatWeapon *pWep);
-	void Weapon_AimToggle(CNEOBaseCombatWeapon* pWep);
+	void Weapon_AimToggle(CBaseCombatWeapon *pWep, const NeoWeponAimToggleE toggleType);
+	void Weapon_AimToggle(CNEOBaseCombatWeapon* pWep, const NeoWeponAimToggleE toggleType);
 
 	void Lean(void);
 	void SoftSuicide(void);

--- a/mp/src/game/shared/neo/neo_player_shared.cpp
+++ b/mp/src/game/shared/neo/neo_player_shared.cpp
@@ -24,7 +24,7 @@ ConVar cl_autoreload_when_empty("cl_autoreload_when_empty", "1", FCVAR_USERINFO,
 	"Automatically start reloading when the active weapon becomes empty.",
 	true, 0.0f, true, 1.0f);
 
-ConVar cl_aimhold("cl_aimhold", "0", FCVAR_USERINFO, "Hold to aim as opposed to toggle aim.", true, 0.0f, true, 1.0f);
+ConVar neo_aim_hold("neo_aim_hold", "0", FCVAR_USERINFO, "Hold to aim as opposed to toggle aim.", true, 0.0f, true, 1.0f);
 
 ConVar neo_recon_superjump_intensity("neo_recon_superjump_intensity", "250", FCVAR_REPLICATED | FCVAR_CHEAT,
 	"Recon superjump intensity multiplier.", true, 1.0, false, 0);

--- a/mp/src/game/shared/neo/neo_player_shared.cpp
+++ b/mp/src/game/shared/neo/neo_player_shared.cpp
@@ -24,6 +24,8 @@ ConVar cl_autoreload_when_empty("cl_autoreload_when_empty", "1", FCVAR_USERINFO,
 	"Automatically start reloading when the active weapon becomes empty.",
 	true, 0.0f, true, 1.0f);
 
+ConVar cl_aimhold("cl_aimhold", "0", FCVAR_USERINFO, "Hold to aim as opposed to toggle aim.", true, 0.0f, true, 1.0f);
+
 ConVar neo_recon_superjump_intensity("neo_recon_superjump_intensity", "250", FCVAR_REPLICATED | FCVAR_CHEAT,
 	"Recon superjump intensity multiplier.", true, 1.0, false, 0);
 

--- a/mp/src/game/shared/neo/neo_player_shared.cpp
+++ b/mp/src/game/shared/neo/neo_player_shared.cpp
@@ -91,3 +91,22 @@ bool PlayerAnimToPlayerAnimEvent(const PLAYER_ANIM playerAnim, PlayerAnimEvent_t
 	else { success = false; }
 	return success;
 }
+
+bool ClientWantsAimHold(const CNEO_Player* player)
+{
+#ifdef CLIENT_DLL
+	return neo_aim_hold.GetBool();
+#else
+	if (!player)
+	{
+		return false;
+	}
+	else if (player->GetFlags() & FL_FAKECLIENT)
+	{
+		return true;
+	}
+
+	return 1 == atoi(engine->GetClientConVarValue(engine->IndexOfEdict(player->edict()), "neo_aim_hold"));
+#endif
+}
+

--- a/mp/src/game/shared/neo/neo_player_shared.h
+++ b/mp/src/game/shared/neo/neo_player_shared.h
@@ -247,6 +247,6 @@ enum NeoWeponAimToggleE {
 	NEO_TOGGLE_FORCE_UN_AIM,
 };
 
-extern ConVar cl_aimhold;
+extern ConVar neo_aim_hold;
 
 #endif // NEO_PLAYER_SHARED_H

--- a/mp/src/game/shared/neo/neo_player_shared.h
+++ b/mp/src/game/shared/neo/neo_player_shared.h
@@ -241,4 +241,12 @@ CBaseCombatWeapon* GetNeoWepWithBits(const CNEO_Player* player, const NEO_WEP_BI
 // Returns true on success. If returns false, the out value will not be set.
 bool PlayerAnimToPlayerAnimEvent(const PLAYER_ANIM playerAnim, PlayerAnimEvent_t& outAnimEvent);
 
+enum NeoWeponAimToggleE {
+	NEO_TOGGLE_DEFAULT = 0,
+	NEO_TOGGLE_FORCE_AIM,
+	NEO_TOGGLE_FORCE_UN_AIM,
+};
+
+extern ConVar cl_aimhold;
+
 #endif // NEO_PLAYER_SHARED_H

--- a/mp/src/game/shared/neo/neo_player_shared.h
+++ b/mp/src/game/shared/neo/neo_player_shared.h
@@ -247,6 +247,6 @@ enum NeoWeponAimToggleE {
 	NEO_TOGGLE_FORCE_UN_AIM,
 };
 
-extern ConVar neo_aim_hold;
+bool ClientWantsAimHold(const CNEO_Player* player);
 
 #endif // NEO_PLAYER_SHARED_H


### PR DESCRIPTION
* The keyboard bind bitmask looks full (max out 32-bits integer), so doing it by cvar instead
* Change aim/ADS behavior
* New cvar: neo_aim_hold, default to 0 for toggle, 1 for hold