### PR TITLE
Separate AUX and cloak/optical camo + OG:NT drain/recover parity

### DIFF
--- a/mp/src/game/client/hl2/c_hl2_playerlocaldata.cpp
+++ b/mp/src/game/client/hl2/c_hl2_playerlocaldata.cpp
@@ -13,6 +13,9 @@
 
 BEGIN_RECV_TABLE_NOBASE( C_HL2PlayerLocalData, DT_HL2Local )
 	RecvPropFloat( RECVINFO(m_flSuitPower) ),
+#ifdef NEO
+	RecvPropFloat(RECVINFO(m_cloakPower)),
+#endif
 	RecvPropInt( RECVINFO(m_bZooming) ),
 	RecvPropInt( RECVINFO(m_bitsActiveDevices) ),
 	RecvPropInt( RECVINFO(m_iSquadMemberCount) ),
@@ -38,6 +41,9 @@ END_PREDICTION_DATA()
 C_HL2PlayerLocalData::C_HL2PlayerLocalData()
 {
 	m_flSuitPower = 0.0;
+#ifdef NEO
+	m_cloakPower = 0.0;
+#endif
 	m_bZooming = false;
 	m_iSquadMemberCount = 0;
 	m_iSquadMedicCount = 0;

--- a/mp/src/game/client/hl2/c_hl2_playerlocaldata.h
+++ b/mp/src/game/client/hl2/c_hl2_playerlocaldata.h
@@ -30,6 +30,10 @@ public:
 	C_HL2PlayerLocalData();
 
 	float	m_flSuitPower;
+#ifdef NEO
+	// In NEO, m_flSuitPower will be treated instead as just running power
+	float	m_cloakPower;
+#endif
 	bool	m_bZooming;
 	int		m_bitsActiveDevices;
 	int		m_iSquadMemberCount;

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -360,7 +360,7 @@ void C_NEO_Player::CheckThermOpticButtons()
 			return;
 		}
 
-		if (m_HL2Local.m_flSuitPower >= CLOAK_AUX_COST)
+		if (m_HL2Local.m_cloakPower >= CLOAK_AUX_COST)
 		{
 			m_bInThermOpticCamo = !m_bInThermOpticCamo;
 		}
@@ -641,7 +641,7 @@ void C_NEO_Player::PreThink( void )
 		{
 			// NEO TODO (Rain): add server style interface for accessor,
 			// so we can share code
-			if (m_HL2Local.m_flSuitPower >= CLOAK_AUX_COST)
+			if (m_HL2Local.m_cloakPower >= CLOAK_AUX_COST)
 			{
 				m_flCamoAuxLastTime = gpGlobals->curtime;
 			}
@@ -655,16 +655,16 @@ void C_NEO_Player::PreThink( void )
 				//SuitPower_Drain(deltaTime * CLOAK_AUX_COST);
 
 				const float auxToDrain = deltaTime * CLOAK_AUX_COST;
-				if (m_HL2Local.m_flSuitPower <= auxToDrain)
+				if (m_HL2Local.m_cloakPower <= auxToDrain)
 				{
-					m_HL2Local.m_flSuitPower = 0;
+					m_HL2Local.m_cloakPower = 0;
 				}
 
-				if (m_HL2Local.m_flSuitPower < CLOAK_AUX_COST)
+				if (m_HL2Local.m_cloakPower < CLOAK_AUX_COST)
 				{
 					m_bInThermOpticCamo = false;
 
-					m_HL2Local.m_flSuitPower = 0;
+					m_HL2Local.m_cloakPower = 0;
 					m_flCamoAuxLastTime = 0;
 				}
 				else

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -652,19 +652,18 @@ void C_NEO_Player::PreThink( void )
 			if (deltaTime >= 1)
 			{
 				// NEO TODO (Rain): add interface for predicting this
-				//SuitPower_Drain(deltaTime * CLOAK_AUX_COST);
 
 				const float auxToDrain = deltaTime * CLOAK_AUX_COST;
 				if (m_HL2Local.m_cloakPower <= auxToDrain)
 				{
-					m_HL2Local.m_cloakPower = 0;
+					m_HL2Local.m_cloakPower = 0.0f;
 				}
 
 				if (m_HL2Local.m_cloakPower < CLOAK_AUX_COST)
 				{
 					m_bInThermOpticCamo = false;
 
-					m_HL2Local.m_cloakPower = 0;
+					m_HL2Local.m_cloakPower = 0.0f;
 					m_flCamoAuxLastTime = 0;
 				}
 				else
@@ -957,6 +956,21 @@ void C_NEO_Player::SuperJump(void)
 	forward.z = 0;
 
 	ApplyAbsVelocityImpulse(forward * neo_recon_superjump_intensity.GetFloat());
+}
+
+float C_NEO_Player::CloakPower_CurrentVisualPercentage(void) const
+{
+	const float cloakPowerRounded = roundf(m_HL2Local.m_cloakPower);
+	switch (GetClass())
+	{
+	case NEO_CLASS_RECON:
+		return (cloakPowerRounded / 13.0f) * 100.0f;
+	case NEO_CLASS_ASSAULT:
+		return (cloakPowerRounded / 8.0f) * 100.0f;
+	default:
+		break;
+	}
+	return 0.0f;
 }
 
 void C_NEO_Player::Spawn( void )

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -1063,7 +1063,7 @@ void C_NEO_Player::Weapon_Drop(C_NEOBaseCombatWeapon *pWeapon)
 
 void C_NEO_Player::StartSprinting(void)
 {
-	if (m_HL2Local.m_flSuitPower < 10)
+	if (m_HL2Local.m_flSuitPower < SPRINT_START_MIN)
 	{
 		return;
 	}

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -104,6 +104,8 @@ public:
 		}
 	}
 
+	float CloakPower_CurrentVisualPercentage(void) const;
+
 	float GetNormSpeed_WithActiveWepEncumberment(void) const;
 	float GetCrouchSpeed_WithActiveWepEncumberment(void) const;
 	float GetWalkSpeed_WithActiveWepEncumberment(void) const;

--- a/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
@@ -99,20 +99,28 @@ void CNEOHud_HTA::DrawHTA() const
 	wchar_t unicodeValue_Aux[4]{ L'\0' };
 
 	const int health = player->GetHealth();
-	const int thermoptic = player->m_HL2Local.m_cloakPower;
+	const int thermopticValue = static_cast<int>(roundf(player->m_HL2Local.m_cloakPower));
+	const float thermopticPercent = player->CloakPower_CurrentVisualPercentage();
 	const int aux = player->m_HL2Local.m_flSuitPower;
+	const bool playerIsNotSupport = (player->GetClass() != NEO_CLASS_SUPPORT);
 
-	itoa(health, value_Integrity, 10);
-	itoa(thermoptic, value_ThermOptic, 10);
-	itoa(aux, value_Aux, 10);
+	inttostr(value_Integrity, 10, health);
+	if (playerIsNotSupport)
+	{
+		inttostr(value_ThermOptic, 10, thermopticValue);
+		inttostr(value_Aux, 10, aux);
+	}
 
 	const int valLen_Integrity = V_strlen(value_Integrity);
 	const int valLen_ThermOptic = V_strlen(value_ThermOptic);
 	const int valLen_Aux = V_strlen(value_Aux);
 
 	g_pVGuiLocalize->ConvertANSIToUnicode(value_Integrity, unicodeValue_Integrity, sizeof(unicodeValue_Integrity));
-	g_pVGuiLocalize->ConvertANSIToUnicode(value_ThermOptic, unicodeValue_ThermOptic, sizeof(unicodeValue_ThermOptic));
-	g_pVGuiLocalize->ConvertANSIToUnicode(value_Aux, unicodeValue_Aux, sizeof(unicodeValue_Aux));
+	if (playerIsNotSupport)
+	{
+		g_pVGuiLocalize->ConvertANSIToUnicode(value_ThermOptic, unicodeValue_ThermOptic, sizeof(unicodeValue_ThermOptic));
+		g_pVGuiLocalize->ConvertANSIToUnicode(value_Aux, unicodeValue_Aux, sizeof(unicodeValue_Aux));
+	}
 
 	int fontWidth, fontHeight;
 	surface()->GetTextSize(m_hFont, L"THERM-OPTIC", fontWidth, fontHeight);
@@ -130,17 +138,23 @@ void CNEOHud_HTA::DrawHTA() const
 	surface()->DrawSetTextColor(textColor);
 	surface()->DrawSetTextPos(xPadding + margin, m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 1 - margin);
 	surface()->DrawPrintText(L"INTEGRITY", 9);
-	surface()->DrawSetTextPos(xPadding + margin, m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 2 - margin);
-	surface()->DrawPrintText(L"THERM-OPTIC", 11);
-	surface()->DrawSetTextPos(xPadding + margin, m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 3 - margin);
-	surface()->DrawPrintText(L"AUX", 3);
+	if (playerIsNotSupport)
+	{
+		surface()->DrawSetTextPos(xPadding + margin, m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 2 - margin);
+		surface()->DrawPrintText(L"THERM-OPTIC", 11);
+		surface()->DrawSetTextPos(xPadding + margin, m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 3 - margin);
+		surface()->DrawPrintText(L"AUX", 3);
+	}
 
 	surface()->DrawSetTextPos(xBoxWidth - xPadding * 7 + margin, m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 1 - margin);
 	surface()->DrawPrintText(unicodeValue_Integrity, valLen_Integrity);
-	surface()->DrawSetTextPos(xBoxWidth - xPadding * 7 + margin, m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 2 - margin);
-	surface()->DrawPrintText(unicodeValue_ThermOptic, valLen_ThermOptic);
-	surface()->DrawSetTextPos(xBoxWidth - xPadding * 7 + margin, m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 3 - margin);
-	surface()->DrawPrintText(unicodeValue_Aux, valLen_Aux);
+	if (playerIsNotSupport)
+	{
+		surface()->DrawSetTextPos(xBoxWidth - xPadding * 7 + margin, m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 2 - margin);
+		surface()->DrawPrintText(unicodeValue_ThermOptic, valLen_ThermOptic);
+		surface()->DrawSetTextPos(xBoxWidth - xPadding * 7 + margin, m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 3 - margin);
+		surface()->DrawPrintText(unicodeValue_Aux, valLen_Aux);
+	}
 
 	surface()->DrawSetColor(COLOR_WHITE);
 
@@ -155,19 +169,22 @@ void CNEOHud_HTA::DrawHTA() const
 		x_to - x_len * (1 - health / 100.0) + margin,
 		m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 1.75 - margin);
 
-	// ThermOptic progress bar
-	surface()->DrawFilledRect(
-		x_from + margin,
-		1.0 * (m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 2) - margin,
-		x_to - x_len * (1 - thermoptic / 100.0) + margin,
-		m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 2.75 - margin);
+	if (playerIsNotSupport)
+	{
+		// ThermOptic progress bar
+		surface()->DrawFilledRect(
+			x_from + margin,
+			1.0 * (m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 2) - margin,
+			x_to - x_len * (1 - thermopticPercent / 100.0) + margin,
+			m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 2.75 - margin);
 
-	// AUX progress bar
-	surface()->DrawFilledRect(
-		x_from + margin,
-		1.0 * (m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 3) - margin,
-		x_to - x_len * (1 - aux / 100.0) + margin,
-		m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 3.75 - margin);
+		// AUX progress bar
+		surface()->DrawFilledRect(
+			x_from + margin,
+			1.0 * (m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 3) - margin,
+			x_to - x_len * (1 - aux / 100.0) + margin,
+			m_resY - yBoxHeight - (fontHeight / 1.5) + fontHeight * 3.75 - margin);
+	}
 }
 
 void CNEOHud_HTA::DrawNeoHudElement()

--- a/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
@@ -99,8 +99,7 @@ void CNEOHud_HTA::DrawHTA() const
 	wchar_t unicodeValue_Aux[4]{ L'\0' };
 
 	const int health = player->GetHealth();
-	// FIXME/TODO (Rain): decouple ThermOptic power from AUX
-	const int thermoptic = player->m_HL2Local.m_flSuitPower;
+	const int thermoptic = player->m_HL2Local.m_cloakPower;
 	const int aux = player->m_HL2Local.m_flSuitPower;
 
 	itoa(health, value_Integrity, 10);

--- a/mp/src/game/server/hl2/hl2_player.cpp
+++ b/mp/src/game/server/hl2/hl2_player.cpp
@@ -1229,7 +1229,11 @@ void CHL2_Player::StartAutoSprint()
 //-----------------------------------------------------------------------------
 void CHL2_Player::StartSprinting( void )
 {
-	if( m_HL2Local.m_flSuitPower < 10 )
+#ifndef NEO
+	if ( m_HL2Local.m_flSuitPower < 10 )
+#else
+	if (m_HL2Local.m_flSuitPower < SPRINT_START_MIN)
+#endif
 	{
 #ifndef NEO
 		// debounce the button for sound playing

--- a/mp/src/game/server/hl2/hl2_player.cpp
+++ b/mp/src/game/server/hl2/hl2_player.cpp
@@ -419,23 +419,22 @@ static inline float GetAuxChargeRate(CBaseCombatCharacter *player)
 {
 	auto neoPlayer = static_cast<CNEO_Player*>(player);
 
-#define BASE_AUX_RATE 10.0
-
 	switch (neoPlayer->GetClass())
 	{
 	case NEO_CLASS_RECON:
-		return BASE_AUX_RATE * 1.2;
+		return 5.0f;	// 100 units in 20 seconds
 	case NEO_CLASS_ASSAULT:
-		return BASE_AUX_RATE;
-	case NEO_CLASS_SUPPORT:
-		return BASE_AUX_RATE * 0.8;
+		return 2.5f;	// 100 units in 40 seconds
 	default:
-		return BASE_AUX_RATE;
+		break;
 	}
+	return 0.0f;
 }
 #endif
 
-#ifdef HL2MP
+#if defined(NEO)
+	CSuitPowerDevice SuitDeviceSprint( bits_SUIT_DEVICE_SPRINT, 5.0f );					// 100 units in 20 seconds
+#elif defined(HL2MP)
 	CSuitPowerDevice SuitDeviceSprint( bits_SUIT_DEVICE_SPRINT, 25.0f );				// 100 units in 4 seconds
 #else
 	CSuitPowerDevice SuitDeviceSprint( bits_SUIT_DEVICE_SPRINT, 12.5f );				// 100 units in 8 seconds

--- a/mp/src/game/server/hl2/hl2_playerlocaldata.cpp
+++ b/mp/src/game/server/hl2/hl2_playerlocaldata.cpp
@@ -16,6 +16,9 @@
 
 BEGIN_SEND_TABLE_NOBASE( CHL2PlayerLocalData, DT_HL2Local )
 	SendPropFloat( SENDINFO(m_flSuitPower), 10, SPROP_UNSIGNED | SPROP_ROUNDUP, 0.0, 100.0 ),
+#ifdef NEO
+	SendPropFloat(SENDINFO(m_cloakPower), 10, SPROP_UNSIGNED | SPROP_ROUNDUP, 0.0, 100.0),
+#endif
 	SendPropInt( SENDINFO(m_bZooming), 1, SPROP_UNSIGNED ),
 	SendPropInt( SENDINFO(m_bitsActiveDevices), MAX_SUIT_DEVICES, SPROP_UNSIGNED ),
 	SendPropInt( SENDINFO(m_iSquadMemberCount) ),
@@ -36,6 +39,9 @@ END_SEND_TABLE()
 
 BEGIN_SIMPLE_DATADESC( CHL2PlayerLocalData )
 	DEFINE_FIELD( m_flSuitPower, FIELD_FLOAT ),
+#ifdef NEO
+	DEFINE_FIELD( m_cloakPower, FIELD_FLOAT ),
+#endif
 	DEFINE_FIELD( m_bZooming, FIELD_BOOLEAN ),
 	DEFINE_FIELD( m_bitsActiveDevices, FIELD_INTEGER ),
 	DEFINE_FIELD( m_iSquadMemberCount, FIELD_INTEGER ),
@@ -56,6 +62,9 @@ END_DATADESC()
 CHL2PlayerLocalData::CHL2PlayerLocalData()
 {
 	m_flSuitPower = 0.0;
+#ifdef NEO
+	m_cloakPower = 0.0;
+#endif
 	m_bZooming = false;
 	m_bWeaponLowered = false;
 	m_hAutoAimTarget.Set(NULL);

--- a/mp/src/game/server/hl2/hl2_playerlocaldata.h
+++ b/mp/src/game/server/hl2/hl2_playerlocaldata.h
@@ -29,6 +29,9 @@ public:
 	CHL2PlayerLocalData();
 
 	CNetworkVar( float, m_flSuitPower );
+#if NEO
+	CNetworkVar( float, m_cloakPower );
+#endif
 	CNetworkVar( bool,	m_bZooming );
 	CNetworkVar( int,	m_bitsActiveDevices );
 	CNetworkVar( int,	m_iSquadMemberCount );

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -612,16 +612,14 @@ void CNEO_Player::PreThink(void)
 			const float deltaTime = gpGlobals->curtime - m_flCamoAuxLastTime;
 			if (deltaTime >= 1)
 			{
-				// Need to have at least this much spare AUX to enable.
-				// This prevents AUX spam abuse where player has a sliver of AUX
+				// Need to have at least this much spare camo to enable.
+				// This prevents camo spam abuse where player has a sliver of camo
 				// each frame to never really run out.
 				CloakPower_Drain(deltaTime * CLOAK_AUX_COST);
 
-				if (m_HL2Local.m_cloakPower < CLOAK_AUX_COST)
+				if (m_HL2Local.m_cloakPower <= 0.1f)
 				{
 					m_bInThermOpticCamo = false;
-
-					m_HL2Local.m_cloakPower = 0.0f;
 					m_flCamoAuxLastTime = 0;
 				}
 				else

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -2165,7 +2165,7 @@ void CNEO_Player::StartAutoSprint(void)
 
 void CNEO_Player::StartSprinting(void)
 {
-	if (GetClass() != NEO_CLASS_RECON && m_HL2Local.m_flSuitPower < 10)
+	if (GetClass() != NEO_CLASS_RECON && m_HL2Local.m_flSuitPower < SPRINT_START_MIN)
 	{
 		return;
 	}

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -147,6 +147,14 @@ public:
 	virtual void StartWalking(void) OVERRIDE;
 	virtual void StopWalking(void) OVERRIDE;
 
+	// Cloak Power Interface
+	void CloakPower_Update(void);
+	bool CloakPower_Drain(float flPower); // consume some of the suit's power.
+	void CloakPower_Charge(float flPower); // add suit power.
+	void CloakPower_SetCharge(float flPower) { m_HL2Local.m_cloakPower = flPower; }
+	bool CloakPower_ShouldRecharge(void);
+	float CloakPower_GetCurrentPercentage(void) { return m_HL2Local.m_cloakPower; }
+
 	float GetNormSpeed_WithActiveWepEncumberment(void) const;
 	float GetCrouchSpeed_WithActiveWepEncumberment(void) const;
 	float GetWalkSpeed_WithActiveWepEncumberment(void) const;

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -149,11 +149,9 @@ public:
 
 	// Cloak Power Interface
 	void CloakPower_Update(void);
-	bool CloakPower_Drain(float flPower); // consume some of the suit's power.
-	void CloakPower_Charge(float flPower); // add suit power.
-	void CloakPower_SetCharge(float flPower) { m_HL2Local.m_cloakPower = flPower; }
-	bool CloakPower_ShouldRecharge(void);
-	float CloakPower_GetCurrentPercentage(void) { return m_HL2Local.m_cloakPower; }
+	bool CloakPower_Drain(float flPower);
+	void CloakPower_Charge(float flPower);
+	float CloakPower_Cap() const;
 
 	float GetNormSpeed_WithActiveWepEncumberment(void) const;
 	float GetCrouchSpeed_WithActiveWepEncumberment(void) const;

--- a/mp/src/game/shared/neo/neo_player_shared.h
+++ b/mp/src/game/shared/neo/neo_player_shared.h
@@ -74,6 +74,7 @@ COMPILE_TIME_ASSERT(NEO_ASSAULT_CROUCH_SPEED > NEO_SUPPORT_CROUCH_SPEED);
 
 #define SUPER_JMP_COST 45.0f
 #define CLOAK_AUX_COST 1.0f
+#define SPRINT_START_MIN (2.0f)
 
 // Original NT allows chaining superjumps up ramps,
 // so leaving this zeroed for enabling movement tricks.

--- a/mp/src/game/shared/neo/neo_player_shared.h
+++ b/mp/src/game/shared/neo/neo_player_shared.h
@@ -73,7 +73,7 @@ COMPILE_TIME_ASSERT(NEO_RECON_CROUCH_SPEED > NEO_ASSAULT_CROUCH_SPEED);
 COMPILE_TIME_ASSERT(NEO_ASSAULT_CROUCH_SPEED > NEO_SUPPORT_CROUCH_SPEED);
 
 #define SUPER_JMP_COST 45.0f
-#define CLOAK_AUX_COST ((GetClass() == NEO_CLASS_RECON) ? 17.5f : 19.0f)
+#define CLOAK_AUX_COST 1.0f
 
 // Original NT allows chaining superjumps up ramps,
 // so leaving this zeroed for enabling movement tricks.


### PR DESCRIPTION
* Basically a camo is sorta like a second AUX-ish really without the device stuff
* Fix sprint blocking camo recharge
* Support hide camo+aux UI
* Lowered/changed some threshold verses HL2MP
* Camo rate now on parity to OG:NT
    * Assault:
        * Max: 8
        * Drain: 1 per second
        * Recover: 0.25 per second
    * Recon:
        * Max: 13
        * Drain: 1 per second
        * Recover: 0.55 per second
* AUX rate now on parity to OG:NT
    * Assault:
        * Drain: 5 per second | 20 secs to empty
        * Recover: 2.5 per second | 40 secs to full
    * Recon:
        * Jump drain: 45 AUX (already done before, just checking)
        * Recover: 5 per second | 20 secs to full