### PR TITLE
Ghost beacon - Fix drop not dropping hud, fix dead players showing up

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -1037,6 +1037,7 @@ void C_NEO_Player::Weapon_Drop(C_NEOBaseCombatWeapon *pWeapon)
 
 	if (pWeapon->IsGhost())
 	{
+		pWeapon->Holster(NULL);
 		Assert(dynamic_cast<C_WeaponGhost*>(pWeapon));
 		static_cast<C_WeaponGhost*>(pWeapon)->HandleGhostUnequip();
 	}

--- a/mp/src/game/shared/neo/weapons/weapon_ghost.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_ghost.cpp
@@ -255,7 +255,7 @@ float CWeaponGhost::ShowEnemies(void)
 		auto otherPlayer = ToBasePlayer( ClientEntityList().GetEnt( i ) );
 
 		// Only ghost valid clients that aren't ourselves
-		if (!otherPlayer || otherPlayer == player)
+		if (!otherPlayer || otherPlayer == player || otherPlayer->IsPlayerDead() || otherPlayer->IsHLTV())
 		{
 			continue;
 		}


### PR DESCRIPTION
* Fix drop not dropping hud: Really just a workaround, just call holster as that doesn't have the issue
* P.S: This doesn't fix for spec, but I'll wait until VantoNortim's client/server position-hud changes to relook at that one