### PR TITLE
Ghost marker - Team coloring, fix darken screen/visuals, improve hud

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -759,9 +759,7 @@ void C_NEO_Player::PreThink( void )
 				const float distance = METERS_PER_INCH *
 					GetAbsOrigin().DistTo(m_vecGhostMarkerPos);
 
-				// NEO HACK (Rain): We should test if we're holding a ghost
-				// instead of relying on a distance check.
-				if (m_iGhosterTeam != GetTeamNumber() || distance > 0.2)
+				if (!IsCarryingGhost())
 				{
 					ghostMarker->SetVisible(true);
 
@@ -769,9 +767,8 @@ void C_NEO_Player::PreThink( void )
 					GetVectorInScreenSpace(m_vecGhostMarkerPos, ghostMarkerX, ghostMarkerY);
 
 					ghostMarker->SetScreenPosition(ghostMarkerX, ghostMarkerY);
-					ghostMarker->SetGhostingTeam(m_iGhosterTeam);
-
-
+					ghostMarker->SetGhostingTeam(NEORules()->ghosterTeam());
+					ghostMarker->SetClientCurrentTeam(GetTeamNumber());
 					ghostMarker->SetGhostDistance(distance);
 				}
 				else

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -68,7 +68,6 @@ IMPLEMENT_CLIENTCLASS_DT(C_NEO_Player, DT_NEO_Player, CNEO_Player)
 	RecvPropInt(RECVINFO(m_iNextSpawnClassChoice)),
 
 	RecvPropVector(RECVINFO(m_vecGhostMarkerPos)),
-	RecvPropInt(RECVINFO(m_iGhosterTeam)),
 	RecvPropBool(RECVINFO(m_bGhostExists)),
 	RecvPropBool(RECVINFO(m_bInThermOpticCamo)),
 	RecvPropBool(RECVINFO(m_bLastTickInThermOpticCamo)),
@@ -317,7 +316,6 @@ C_NEO_Player::C_NEO_Player()
 	m_iCapTeam = TEAM_UNASSIGNED;
 	m_iLoadoutWepChoice = 0;
 	m_iNextSpawnClassChoice = -1;
-	m_iGhosterTeam = TEAM_UNASSIGNED;
 	m_iXP.GetForModify() = 0;
 
 	m_vecGhostMarkerPos = vec3_origin;

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -187,8 +187,6 @@ public:
 
 	CNetworkVector(m_vecGhostMarkerPos);
 
-	CNetworkVar(int, m_iGhosterTeam); // TODO (nullsystem): Remove? Never used/replaced by gamerules
-
 	CNetworkVar(bool, m_bInThermOpticCamo);
 	CNetworkVar(bool, m_bLastTickInThermOpticCamo);
 	CNetworkVar(bool, m_bInVision);

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -187,7 +187,7 @@ public:
 
 	CNetworkVector(m_vecGhostMarkerPos);
 
-	CNetworkVar(int, m_iGhosterTeam);
+	CNetworkVar(int, m_iGhosterTeam); // TODO (nullsystem): Remove? Never used/replaced by gamerules
 
 	CNetworkVar(bool, m_bInThermOpticCamo);
 	CNetworkVar(bool, m_bLastTickInThermOpticCamo);

--- a/mp/src/game/client/neo/ui/neo_hud_compass.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.cpp
@@ -253,7 +253,7 @@ void CNEOHud_Compass::DrawCompass() const
 
 				ghostMarkerX = clamp(ghostMarkerX, resXHalf - xBoxWidthHalf, resXHalf + xBoxWidthHalf);
 
-				const int ghosterTeam = player->m_iGhosterTeam;
+				const int ghosterTeam = NEORules()->ghosterTeam();
 				const int ownTeam = player->GetTeam()->GetTeamNumber();
 
 				const auto teamClr32 = player->GetTeam()->GetRenderColor();

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
@@ -128,6 +128,8 @@ void CNEOHud_GhostMarker::DrawNeoHudElement()
 
 void CNEOHud_GhostMarker::Paint()
 {
+	SetFgColor(COLOR_TRANSPARENT);
+	SetBgColor(COLOR_TRANSPARENT);
 	BaseClass::Paint();
 	PaintNeoElement();
 }

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
@@ -93,11 +93,6 @@ void CNEOHud_GhostMarker::DrawNeoHudElement()
 		return;
 	}
 
-	surface()->DrawSetTextColor(COLOR_GREY);
-	surface()->DrawSetTextFont(m_hFont);
-	surface()->DrawSetTextPos(m_iPosX, m_iPosY);
-	surface()->DrawPrintText(m_wszMarkerTextUnicode, sizeof(m_szMarkerText));
-
 	const float scale = neo_ghost_marker_hud_scale_factor.GetFloat();
 
 	const int offset_X = m_iPosX - ((m_iMarkerTexWidth * 0.5f) * scale);
@@ -124,6 +119,14 @@ void CNEOHud_GhostMarker::DrawNeoHudElement()
 		offset_Y,
 		offset_X + (m_iMarkerTexWidth * scale),
 		offset_Y + (m_iMarkerTexHeight * scale));
+
+	surface()->DrawSetTextColor(COLOR_GREY);
+	int xWide = 0;
+	int yTall = 0;
+	surface()->GetTextSize(m_hFont, m_wszMarkerTextUnicode, xWide, yTall);
+	surface()->DrawSetTextFont(m_hFont);
+	surface()->DrawSetTextPos(m_iPosX - (xWide / 2), offset_Y + (m_iMarkerTexHeight * scale) + (yTall / 2));
+	surface()->DrawPrintText(m_wszMarkerTextUnicode, sizeof(m_szMarkerText));
 }
 
 void CNEOHud_GhostMarker::Paint()

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
@@ -103,7 +103,21 @@ void CNEOHud_GhostMarker::DrawNeoHudElement()
 	const int offset_X = m_iPosX - ((m_iMarkerTexWidth * 0.5f) * scale);
 	const int offset_Y = m_iPosY - ((m_iMarkerTexHeight * 0.5f) * scale);
 
-	surface()->DrawSetColor(m_iGhostingTeam == TEAM_JINRAI ? COLOR_JINRAI : (m_iGhostingTeam == TEAM_NSF ? COLOR_NSF : COLOR_GREY));
+	Color ghostColor = COLOR_GREY;
+	if (m_iGhostingTeam == TEAM_JINRAI || m_iGhostingTeam == TEAM_NSF)
+	{
+		if ((m_iClientTeam == TEAM_JINRAI || m_iClientTeam == TEAM_NSF) && (m_iClientTeam != m_iGhostingTeam))
+		{
+			// If viewing from playing player, but opposite of ghosting team, show red
+			ghostColor = COLOR_RED;
+		}
+		else
+		{
+			// Otherwise show ghosting team color (if friendly or spec)
+			ghostColor = (m_iGhostingTeam == TEAM_JINRAI) ? COLOR_JINRAI : COLOR_NSF;
+		}
+	}
+	surface()->DrawSetColor(ghostColor);
 	surface()->DrawSetTexture(m_hTex);
 	surface()->DrawTexturedRect(
 		offset_X,
@@ -121,6 +135,11 @@ void CNEOHud_GhostMarker::Paint()
 void CNEOHud_GhostMarker::SetGhostingTeam(int team)
 {
 	m_iGhostingTeam = team;
+}
+
+void CNEOHud_GhostMarker::SetClientCurrentTeam(int team)
+{
+	m_iClientTeam = team;
 }
 
 void CNEOHud_GhostMarker::SetScreenPosition(int x, int y)

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_marker.h
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_marker.h
@@ -18,6 +18,7 @@ public:
 	virtual void Paint();
 
 	void SetGhostingTeam(int team);
+	void SetClientCurrentTeam(int team);
 	void SetScreenPosition(int x, int y);
 	void SetGhostDistance(float distance);
 
@@ -30,6 +31,7 @@ private:
 	int m_iMarkerTexWidth, m_iMarkerTexHeight;
 	int m_iPosX, m_iPosY;
 	int m_iGhostingTeam;
+	int m_iClientTeam;
 
 	char m_szMarkerText[12 + 1];
 	wchar_t m_wszMarkerTextUnicode[12 + 1];

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -713,7 +713,21 @@ void CNEO_Player::PreThink(void)
 
 		if (ghost->GetAbsOrigin().IsValid())
 		{
-			m_vecGhostMarkerPos = ghost->GetAbsOrigin();
+			Vector vecNextGhostMarkerPos = ghost->GetAbsOrigin();
+			const int ghosterTeam = NEORules()->ghosterTeam();
+			if (ghosterTeam == TEAM_JINRAI || ghosterTeam == TEAM_NSF)
+			{
+				// Someone's carrying it, center at their body
+				const int playerIdx = NEORules()->GetGhosterPlayer();
+				if (auto player = static_cast<CNEO_Player*>(UTIL_PlayerByIndex(playerIdx)))
+				{
+					const Vector playerEye = player->EyePosition();
+					const Vector playerBase = player->GetAbsOrigin();
+					const float playerMidZ = (playerEye.z - playerBase.z) / 2.0f;
+					vecNextGhostMarkerPos = Vector(playerBase.x, playerBase.y, playerBase.z + playerMidZ);
+				}
+			}
+			m_vecGhostMarkerPos = vecNextGhostMarkerPos;
 		}
 		else
 		{

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -47,7 +47,6 @@ SendPropInt(SENDINFO(m_iNeoSkin)),
 SendPropInt(SENDINFO(m_iNeoStar)),
 SendPropInt(SENDINFO(m_iXP)),
 SendPropInt(SENDINFO(m_iCapTeam), 3),
-SendPropInt(SENDINFO(m_iGhosterTeam)),
 SendPropInt(SENDINFO(m_iLoadoutWepChoice)),
 SendPropInt(SENDINFO(m_iNextSpawnClassChoice)),
 
@@ -77,7 +76,6 @@ DEFINE_FIELD(m_iNeoSkin, FIELD_INTEGER),
 DEFINE_FIELD(m_iNeoStar, FIELD_INTEGER),
 DEFINE_FIELD(m_iXP, FIELD_INTEGER),
 DEFINE_FIELD(m_iCapTeam, FIELD_INTEGER),
-DEFINE_FIELD(m_iGhosterTeam, FIELD_INTEGER),
 DEFINE_FIELD(m_iLoadoutWepChoice, FIELD_INTEGER),
 DEFINE_FIELD(m_iNextSpawnClassChoice, FIELD_INTEGER),
 
@@ -359,7 +357,6 @@ CNEO_Player::CNEO_Player()
 	m_bInAim = false;
 
 	m_iCapTeam = TEAM_UNASSIGNED;
-	m_iGhosterTeam = TEAM_UNASSIGNED;
 	m_iLoadoutWepChoice = 0;
 	m_iNextSpawnClassChoice = -1;
 

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -190,7 +190,6 @@ public:
 	CNetworkString(m_pszTestMessage, 32 * 2 + 1);
 
 	CNetworkVector(m_vecGhostMarkerPos);
-	CNetworkVar(int, m_iGhosterTeam);
 	CNetworkVar(bool, m_bGhostExists);
 	CNetworkVar(bool, m_bInThermOpticCamo);
 	CNetworkVar(bool, m_bLastTickInThermOpticCamo);

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -35,11 +35,13 @@ BEGIN_NETWORK_TABLE_NOBASE( CNEORules, DT_NEORules )
 	RecvPropFloat(RECVINFO(m_flNeoRoundStartTime)),
 	RecvPropInt(RECVINFO(m_nRoundStatus)),
 	RecvPropInt(RECVINFO(m_iRoundNumber)),
+	RecvPropInt(RECVINFO(m_iGhosterTeam)),
 #else
 	SendPropFloat(SENDINFO(m_flNeoNextRoundStartTime)),
 	SendPropFloat(SENDINFO(m_flNeoRoundStartTime)),
 	SendPropInt(SENDINFO(m_nRoundStatus)),
 	SendPropInt(SENDINFO(m_iRoundNumber)),
+	SendPropInt(SENDINFO(m_iGhosterTeam)),
 #endif
 END_NETWORK_TABLE()
 
@@ -237,6 +239,7 @@ CNEORules::CNEORules()
 	m_flNeoRoundStartTime = m_flNeoNextRoundStartTime = 0;
 	SetRoundStatus(NeoRoundStatus::Idle);
 	m_iRoundNumber = 0;
+	m_iGhosterTeam = TEAM_UNASSIGNED;
 
 	ListenForGameEvent("round_start");
 }
@@ -355,6 +358,7 @@ void CNEORules::ChangeLevel(void)
 {
 	SetRoundStatus(NeoRoundStatus::Idle);
 	m_iRoundNumber = 0;
+	m_iGhosterTeam = TEAM_UNASSIGNED;
 	m_flNeoRoundStartTime = 0;
 	m_flNeoNextRoundStartTime = 0;
 
@@ -371,6 +375,7 @@ bool CNEORules::CheckGameOver(void)
 	{
 		SetRoundStatus(NeoRoundStatus::Idle);
 		m_iRoundNumber = 0;
+		m_iGhosterTeam = TEAM_UNASSIGNED;
 		m_flNeoRoundStartTime = 0;
 		m_flNeoNextRoundStartTime = 0;
 	}
@@ -453,6 +458,20 @@ void CNEORules::Think(void)
 	{
 		SetWinningTeam(TEAM_SPECTATOR, NEO_VICTORY_STALEMATE, false, false, true, false);
 	}
+
+	// Update ghosting team info
+	int nextGhosterTeam = TEAM_UNASSIGNED;
+	for (int i = 1; i <= gpGlobals->maxClients; i++)
+	{
+		auto player = static_cast<CNEO_Player*>(UTIL_PlayerByIndex(i));
+		if (player && player->IsCarryingGhost())
+		{
+			nextGhosterTeam = player->GetTeamNumber();
+			Assert(nextGhosterTeam == TEAM_JINRAI || nextGhosterTeam == TEAM_NSF);
+			break;
+		}
+	}
+	m_iGhosterTeam = nextGhosterTeam;
 
 	// Check if the ghost was capped during this Think
 	int captorTeam, captorClient;
@@ -1115,6 +1134,7 @@ void CNEORules::RestartGame()
 	m_flRestartGameTime = 0.0;
 	m_bCompleteReset = false;
 	m_iRoundNumber = 0;
+	m_iGhosterTeam = TEAM_UNASSIGNED;
 	m_flNeoNextRoundStartTime = FLT_MAX;
 	m_flNeoRoundStartTime = FLT_MAX;
 

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -36,12 +36,14 @@ BEGIN_NETWORK_TABLE_NOBASE( CNEORules, DT_NEORules )
 	RecvPropInt(RECVINFO(m_nRoundStatus)),
 	RecvPropInt(RECVINFO(m_iRoundNumber)),
 	RecvPropInt(RECVINFO(m_iGhosterTeam)),
+	RecvPropInt(RECVINFO(m_iGhosterPlayer)),
 #else
 	SendPropFloat(SENDINFO(m_flNeoNextRoundStartTime)),
 	SendPropFloat(SENDINFO(m_flNeoRoundStartTime)),
 	SendPropInt(SENDINFO(m_nRoundStatus)),
 	SendPropInt(SENDINFO(m_iRoundNumber)),
 	SendPropInt(SENDINFO(m_iGhosterTeam)),
+	SendPropInt(SENDINFO(m_iGhosterPlayer)),
 #endif
 END_NETWORK_TABLE()
 
@@ -240,6 +242,7 @@ CNEORules::CNEORules()
 	SetRoundStatus(NeoRoundStatus::Idle);
 	m_iRoundNumber = 0;
 	m_iGhosterTeam = TEAM_UNASSIGNED;
+	m_iGhosterPlayer = 0;
 
 	ListenForGameEvent("round_start");
 }
@@ -359,6 +362,7 @@ void CNEORules::ChangeLevel(void)
 	SetRoundStatus(NeoRoundStatus::Idle);
 	m_iRoundNumber = 0;
 	m_iGhosterTeam = TEAM_UNASSIGNED;
+	m_iGhosterPlayer = 0;
 	m_flNeoRoundStartTime = 0;
 	m_flNeoNextRoundStartTime = 0;
 
@@ -376,6 +380,7 @@ bool CNEORules::CheckGameOver(void)
 		SetRoundStatus(NeoRoundStatus::Idle);
 		m_iRoundNumber = 0;
 		m_iGhosterTeam = TEAM_UNASSIGNED;
+		m_iGhosterPlayer = 0;
 		m_flNeoRoundStartTime = 0;
 		m_flNeoNextRoundStartTime = 0;
 	}
@@ -461,17 +466,20 @@ void CNEORules::Think(void)
 
 	// Update ghosting team info
 	int nextGhosterTeam = TEAM_UNASSIGNED;
+	int nextGhosterPlayer = 0;
 	for (int i = 1; i <= gpGlobals->maxClients; i++)
 	{
 		auto player = static_cast<CNEO_Player*>(UTIL_PlayerByIndex(i));
 		if (player && player->IsCarryingGhost())
 		{
 			nextGhosterTeam = player->GetTeamNumber();
+			nextGhosterPlayer = i;
 			Assert(nextGhosterTeam == TEAM_JINRAI || nextGhosterTeam == TEAM_NSF);
 			break;
 		}
 	}
 	m_iGhosterTeam = nextGhosterTeam;
+	m_iGhosterPlayer = nextGhosterPlayer;
 
 	// Check if the ghost was capped during this Think
 	int captorTeam, captorClient;

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -209,6 +209,7 @@ public:
 	};
 
 	int ghosterTeam() const { return m_iGhosterTeam; }
+	int GetGhosterPlayer() const { return m_iGhosterPlayer; }
 
 	int GetOpposingTeam(const int team) const
 	{
@@ -242,6 +243,7 @@ private:
 	CNetworkVar(int, m_nRoundStatus); // NEO TODO (Rain): probably don't need to network this
 	CNetworkVar(int, m_iRoundNumber);
 	CNetworkVar(int, m_iGhosterTeam);
+	CNetworkVar(int, m_iGhosterPlayer);
 
 	CNetworkVar(float, m_flNeoRoundStartTime);
 	CNetworkVar(float, m_flNeoNextRoundStartTime);

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -208,6 +208,8 @@ public:
 		NEO_VICTORY_STALEMATE // Not actually a victory
 	};
 
+	int ghosterTeam() const { return m_iGhosterTeam; }
+
 	int GetOpposingTeam(const int team) const
 	{
 		if (team == TEAM_JINRAI) { return TEAM_NSF; }
@@ -239,6 +241,7 @@ private:
 #endif
 	CNetworkVar(int, m_nRoundStatus); // NEO TODO (Rain): probably don't need to network this
 	CNetworkVar(int, m_iRoundNumber);
+	CNetworkVar(int, m_iGhosterTeam);
 
 	CNetworkVar(float, m_flNeoRoundStartTime);
 	CNetworkVar(float, m_flNeoNextRoundStartTime);


### PR DESCRIPTION
* Team coloring:
    * Gray by default, no ghost carrier
    * Red if viewed by playing player, but ghost carried by other team
    * Team color of ghost carrier if viewed by friendly playing player, or spectator
* Hud positioning:
    * Text now centered under the circle
    * When player carrying ghost, now centered on the body by z-axis
* Code refactor: Removed `m_iGhosterTeam` from player, moved to gamerules
* Bug fixes:
    * Fix screen darken because of NT-style font, set transparency
    * Prevent showing marker to the current ghost carrier