### PR TITLE
Ghost beacon - Startup visibility delay

### DIFF
--- a/mp/src/game/shared/neo/weapons/weapon_ghost.h
+++ b/mp/src/game/shared/neo/weapons/weapon_ghost.h
@@ -73,6 +73,7 @@ private:
 	bool m_bHaveHolsteredTheGhost;
 
 	float m_flLastGhostBeepTime;
+	float m_flNextAllowGhostShowTime;
 
 	// NEO TODO (Rain): It's probably better to just have one beacon,
 	// and call it numplayers times on each update between hud buffer swaps


### PR DESCRIPTION
* This is also tweakable using neo_ghost_delay_secs, but server-side and sv_cheats 1 only. Defaults to 2.35, but that in real-time is more like 3.5 ish accounting for delays by switching to ghost also.
* This will get it close to OG:NT delay of approximate 3 half seconds.